### PR TITLE
switch to miniaudio backend and fix orphaned audio process in tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,16 @@ v0.11+ on Linux and macOS!
   performance reasons, but not required; check `:version`)
 - Linux or macOS. (macOS support courtesy of [@sockthedev](https://github.com/sockthedev))
 - C compiler with support for the [C99 standard](https://en.wikipedia.org/wiki/C99).
+- For sound effects, an external audio player such as `ffplay`, `mpv`,
+  `pw-play`, `paplay`, `aplay`, or `afplay`.
 
 ## How to play
 
 Install it via your favourite package manager like any other plugin, then run
 `:Doom`.
+
+Sound effects are played by spawning an external audio player from Neovim.
+Music is still not implemented.
 
 The [shareware version](https://www.doomworld.com/classicdoom/info/shareware.php)
 of DOOM is included for your convenience.

--- a/doc/actually-doom.txt
+++ b/doc/actually-doom.txt
@@ -14,6 +14,8 @@ To use this plugin, the following is required:
   not required; check `:version`)
 - Linux or macOS. (macOS support courtesy of @sockthedev on GitHub)
 - C compiler with support for the C99 standard.
+- For sound effects, an external audio player such as `ffplay`, `mpv`,
+  `pw-play`, `paplay`, `aplay`, or `afplay`.
 
 ==============================================================================
 COMMANDS					*actually-doom-commands*
@@ -26,6 +28,9 @@ COMMANDS					*actually-doom-commands*
 			If [!] or [iwad] is present then a new instance of
 			DOOM is started regardless of whether one is already
 			running.
+
+			Sound effects are played via an external audio player
+			spawned by Nvim.  Music is currently unsupported.
 
 ==============================================================================
 GAME CONTROLS				*actually-doom-game-controls*

--- a/doom/src/doomgeneric_actually.c
+++ b/doom/src/doomgeneric_actually.c
@@ -99,6 +99,9 @@ enum {
     // AMSG_FRAME_FINALE, text_len: u16
     AMSG_FRAME_FINALE = 11,
 
+    // AMSG_SOUND, volume: u8, sep: u8, lump_len: u32, lump_data: u8[]
+    AMSG_SOUND = 12,
+
     // AMSG_SET_TITLE, title: string
     AMSG_SET_TITLE = 1,
 
@@ -367,6 +370,20 @@ static void Comm_WriteString(const char *s)
 
     Comm_Write16(len);
     Comm_WriteBytes((byte *)s, len);
+}
+
+void DG_PlaySound(const byte *lump_data, size_t lump_len, int volume, int sep)
+{
+    if (comm_sock_fd < 0 || lump_len > UINT32_MAX)
+        return;
+
+    COMM_WRITE_MSG({
+        Comm_Write8(AMSG_SOUND);
+        Comm_Write8(volume);
+        Comm_Write8(sep);
+        Comm_Write32((uint32_t)lump_len);
+        Comm_WriteBytes(lump_data, lump_len);
+    });
 }
 
 static void UnlinkFrameShm(void);

--- a/doom/src/doomgeneric_actually.c
+++ b/doom/src/doomgeneric_actually.c
@@ -99,7 +99,7 @@ enum {
     // AMSG_FRAME_FINALE, text_len: u16
     AMSG_FRAME_FINALE = 11,
 
-    // AMSG_SOUND, volume: u8, sep: u8, lump_len: u32, lump_data: u8[]
+    // AMSG_SOUND, volume: u8, lump_len: u32, lump_data: u8[]
     AMSG_SOUND = 12,
 
     // AMSG_SET_TITLE, title: string
@@ -372,7 +372,7 @@ static void Comm_WriteString(const char *s)
     Comm_WriteBytes((byte *)s, len);
 }
 
-void DG_PlaySound(const byte *lump_data, size_t lump_len, int volume, int sep)
+void DG_PlaySound(const byte *lump_data, size_t lump_len, int volume)
 {
     if (comm_sock_fd < 0 || lump_len > UINT32_MAX)
         return;
@@ -380,7 +380,6 @@ void DG_PlaySound(const byte *lump_data, size_t lump_len, int volume, int sep)
     COMM_WRITE_MSG({
         Comm_Write8(AMSG_SOUND);
         Comm_Write8(volume);
-        Comm_Write8(sep);
         Comm_Write32((uint32_t)lump_len);
         Comm_WriteBytes(lump_data, lump_len);
     });

--- a/doom/src/i_sound.c
+++ b/doom/src/i_sound.c
@@ -28,6 +28,9 @@
 #include "i_video.h"
 #include "m_argv.h"
 #include "m_config.h"
+#include "m_misc.h"
+#include "w_wad.h"
+#include "z_zone.h"
 
 // Sound sample rate to use for digital output (Hz)
 
@@ -51,6 +54,9 @@ char *snd_musiccmd = "";
 
 static sound_module_t *sound_module = NULL;
 static music_module_t *music_module = NULL;
+static boolean dg_use_sfx_prefix = false;
+
+void DG_PlaySound(const byte *lump_data, size_t lump_len, int volume, int sep);
 
 int snd_musicdevice = SNDDEVICE_SB;
 int snd_sfxdevice = SNDDEVICE_SB;
@@ -131,6 +137,7 @@ static void InitMusicModule(void)
 void I_InitSound(boolean use_sfx_prefix)
 {
     boolean nosound, nosfx, nomusic;
+    dg_use_sfx_prefix = use_sfx_prefix;
 
     //!
     // @vanilla
@@ -180,13 +187,25 @@ void I_ShutdownSound(void)
     }
 }
 
+static int GetSfxLumpNumFallback(sfxinfo_t *sfxinfo)
+{
+    char namebuf[16];
+
+    if (dg_use_sfx_prefix) {
+        M_snprintf(namebuf, sizeof(namebuf), "ds%s", sfxinfo->name);
+    } else {
+        M_snprintf(namebuf, sizeof(namebuf), "%s", sfxinfo->name);
+    }
+
+    return W_GetNumForName(namebuf);
+}
+
 int I_GetSfxLumpNum(sfxinfo_t *sfxinfo)
 {
-    if (sound_module != NULL) {
+    if (sound_module != NULL)
         return sound_module->GetSfxLumpNum(sfxinfo);
-    } else {
-        return 0;
-    }
+
+    return GetSfxLumpNumFallback(sfxinfo);
 }
 
 void I_UpdateSound(void)
@@ -228,9 +247,16 @@ int I_StartSound(sfxinfo_t *sfxinfo, int channel, int vol, int sep)
     if (sound_module != NULL) {
         CheckVolumeSeparation(&vol, &sep);
         return sound_module->StartSound(sfxinfo, channel, vol, sep);
-    } else {
-        return 0;
     }
+
+    CheckVolumeSeparation(&vol, &sep);
+
+    int lumpnum = sfxinfo->lumpnum >= 0 ? sfxinfo->lumpnum
+                                        : GetSfxLumpNumFallback(sfxinfo);
+    void *data = W_CacheLumpNum(lumpnum, PU_STATIC);
+    DG_PlaySound(data, W_LumpLength(lumpnum), vol, sep);
+    W_ReleaseLumpNum(lumpnum);
+    return channel;
 }
 
 void I_StopSound(int channel)

--- a/doom/src/i_sound.c
+++ b/doom/src/i_sound.c
@@ -56,7 +56,7 @@ static sound_module_t *sound_module = NULL;
 static music_module_t *music_module = NULL;
 static boolean dg_use_sfx_prefix = false;
 
-void DG_PlaySound(const byte *lump_data, size_t lump_len, int volume, int sep);
+void DG_PlaySound(const byte *lump_data, size_t lump_len, int volume);
 
 int snd_musicdevice = SNDDEVICE_SB;
 int snd_sfxdevice = SNDDEVICE_SB;
@@ -244,17 +244,16 @@ void I_UpdateSoundParams(int channel, int vol, int sep)
 
 int I_StartSound(sfxinfo_t *sfxinfo, int channel, int vol, int sep)
 {
+    CheckVolumeSeparation(&vol, &sep);
+
     if (sound_module != NULL) {
-        CheckVolumeSeparation(&vol, &sep);
         return sound_module->StartSound(sfxinfo, channel, vol, sep);
     }
 
-    CheckVolumeSeparation(&vol, &sep);
-
-    int lumpnum = sfxinfo->lumpnum >= 0 ? sfxinfo->lumpnum
-                                        : GetSfxLumpNumFallback(sfxinfo);
+    int lumpnum =
+        sfxinfo->lumpnum >= 0 ? sfxinfo->lumpnum : GetSfxLumpNumFallback(sfxinfo);
     void *data = W_CacheLumpNum(lumpnum, PU_STATIC);
-    DG_PlaySound(data, W_LumpLength(lumpnum), vol, sep);
+    DG_PlaySound(data, W_LumpLength(lumpnum), vol);
     W_ReleaseLumpNum(lumpnum);
     return channel;
 }

--- a/lua/actually-doom/game.lua
+++ b/lua/actually-doom/game.lua
@@ -70,6 +70,7 @@ local M = {
 --- @field process vim.SystemObj
 --- @field sock uv.uv_pipe_t
 --- @field send_buf StrBuf
+--- @field sound ActuallyDoomSound?
 --- @field check_timer uv.uv_timer_t
 --- @field check_scheduled boolean?
 --- @field pressed_key PressedKey?
@@ -781,6 +782,19 @@ local function recv_msg_loop(doom, buf)
       end
     end,
 
+    -- AMSG_SOUND
+    [12] = function()
+      local volume = read_u8()
+      local sep = read_u8()
+      local lump = read_bytes(read_u32())
+
+      if doom.sound then
+        vim.schedule(function()
+          doom.sound:play(lump, volume, sep)
+        end)
+      end
+    end,
+
     -- AMSG_FRAME_SHM_READY
     [3] = function()
       local kitty_gfx = doom.screen:kitty_gfx()
@@ -965,6 +979,7 @@ function Doom.run(console, exe_path, opts)
   local doom = setmetatable({
     console = console,
     play_opts = opts,
+    sound = require("actually-doom.sound").new(console),
     check_timer = assert(uv.new_timer()),
     send_buf = strbuf.new(256),
     mouse_button_mask = 0,
@@ -1014,6 +1029,9 @@ function Doom:close()
   end
   if self.process then
     self.process:kill "sigterm" -- Try a clean shutdown.
+  end
+  if self.sound then
+    self.sound:close()
   end
   -- Close console before the screen so it doesn't print the "buffer was
   -- unloaded" message from us closing the screen.

--- a/lua/actually-doom/game.lua
+++ b/lua/actually-doom/game.lua
@@ -70,7 +70,6 @@ local M = {
 --- @field process vim.SystemObj
 --- @field sock uv.uv_pipe_t
 --- @field send_buf StrBuf
---- @field sound ActuallyDoomSound?
 --- @field check_timer uv.uv_timer_t
 --- @field check_scheduled boolean?
 --- @field pressed_key PressedKey?
@@ -785,12 +784,11 @@ local function recv_msg_loop(doom, buf)
     -- AMSG_SOUND
     [12] = function()
       local volume = read_u8()
-      local sep = read_u8()
       local lump = read_bytes(read_u32())
 
       if doom.sound then
         vim.schedule(function()
-          doom.sound:play(lump, volume, sep)
+          doom.sound:play(lump, volume)
         end)
       end
     end,
@@ -1029,9 +1027,6 @@ function Doom:close()
   end
   if self.process then
     self.process:kill "sigterm" -- Try a clean shutdown.
-  end
-  if self.sound then
-    self.sound:close()
   end
   -- Close console before the screen so it doesn't print the "buffer was
   -- unloaded" message from us closing the screen.

--- a/lua/actually-doom/sound.lua
+++ b/lua/actually-doom/sound.lua
@@ -1,0 +1,266 @@
+local bit = require "bit"
+local fn = vim.fn
+local fs = vim.fs
+local uv = vim.uv
+
+--- @class (exact) ActuallyDoomSound
+--- @field console Console
+--- @field backend table?
+--- @field tmp_dir string?
+--- @field warned_missing_backend boolean
+--- @field warned_decode boolean
+--- @field active table<string, vim.SystemObj>
+---
+--- @field new function
+local M = {}
+
+local backends = {
+  {
+    exe = "ffplay",
+    cmd = function(path)
+      return { "ffplay", "-autoexit", "-nodisp", "-loglevel", "quiet", path }
+    end,
+  },
+  {
+    exe = "mpv",
+    cmd = function(path)
+      return {
+        "mpv",
+        "--no-terminal",
+        "--really-quiet",
+        "--audio-display=no",
+        path,
+      }
+    end,
+  },
+  {
+    exe = "pw-play",
+    cmd = function(path)
+      return { "pw-play", path }
+    end,
+  },
+  {
+    exe = "paplay",
+    cmd = function(path)
+      return { "paplay", path }
+    end,
+  },
+  {
+    exe = "aplay",
+    cmd = function(path)
+      return { "aplay", "-q", path }
+    end,
+  },
+  {
+    exe = "afplay",
+    cmd = function(path)
+      return { "afplay", path }
+    end,
+  },
+}
+
+local backend_names = "ffplay, mpv, pw-play, paplay, aplay, afplay"
+
+local function le_u16(n)
+  return string.char(bit.band(n, 0xff), bit.band(bit.rshift(n, 8), 0xff))
+end
+
+local function le_u32(n)
+  return string.char(
+    bit.band(n, 0xff),
+    bit.band(bit.rshift(n, 8), 0xff),
+    bit.band(bit.rshift(n, 16), 0xff),
+    bit.band(bit.rshift(n, 24), 0xff)
+  )
+end
+
+local function scale_pcm_u8(pcm, volume)
+  if volume >= 127 then
+    return pcm
+  end
+
+  local scaled = {}
+  for i = 1, #pcm do
+    local sample = pcm:byte(i) - 128
+    sample = math.floor((sample * volume) / 127 + 0.5)
+    scaled[i] = string.char(math.max(0, math.min(255, sample + 128)))
+  end
+  return table.concat(scaled)
+end
+
+local function dmx_to_wav(lump, volume)
+  if #lump < 8 then
+    return nil, "DMX lump too short"
+  end
+
+  local format = lump:byte(1) + bit.lshift(lump:byte(2), 8)
+  if format ~= 3 then
+    return nil, ("Unsupported DMX format: %d"):format(format)
+  end
+
+  local sample_rate = lump:byte(3) + bit.lshift(lump:byte(4), 8)
+  local sample_count = lump:byte(5)
+    + bit.lshift(lump:byte(6), 8)
+    + bit.lshift(lump:byte(7), 16)
+    + bit.lshift(lump:byte(8), 24)
+
+  local available = #lump - 8
+  if sample_count > available then
+    sample_count = available
+  end
+  if sample_rate <= 0 or sample_count <= 0 then
+    return nil, "DMX lump has invalid metadata"
+  end
+
+  local pcm = lump:sub(9, 8 + sample_count)
+  pcm = scale_pcm_u8(pcm, volume)
+
+  local header = table.concat({
+    "RIFF",
+    le_u32(36 + #pcm),
+    "WAVE",
+    "fmt ",
+    le_u32(16),
+    le_u16(1),
+    le_u16(1),
+    le_u32(sample_rate),
+    le_u32(sample_rate),
+    le_u16(1),
+    le_u16(8),
+    "data",
+    le_u32(#pcm),
+  })
+
+  return header .. pcm
+end
+
+local function write_file(path, data)
+  local fd, open_err = uv.fs_open(path, "w", 384)
+  if not fd then
+    return nil, open_err
+  end
+
+  local written, write_err = uv.fs_write(fd, data, -1)
+  local closed_ok, close_err = uv.fs_close(fd)
+  if not written then
+    return nil, write_err
+  end
+  if not closed_ok then
+    return nil, close_err
+  end
+
+  return true
+end
+
+local function detect_backend()
+  for _, backend in ipairs(backends) do
+    if fn.executable(backend.exe) == 1 then
+      return backend
+    end
+  end
+end
+
+local function cleanup_path(console, path)
+  local ok, err = pcall(fs.rm, path)
+  if not ok and err then
+    console:plugin_print(
+      ("Failed to delete temporary sound file: %s\n"):format(err),
+      "Warn"
+    )
+  end
+end
+
+--- @param console Console
+--- @return ActuallyDoomSound
+function M.new(console)
+  local tmp_dir_template =
+    fs.joinpath(fn.stdpath("run"), "actually-doom-sound.XXXXXX")
+  local tmp_dir, mkdtemp_err = uv.fs_mkdtemp(tmp_dir_template)
+  if not tmp_dir then
+    console:plugin_print(
+      ("Failed to create sound temp dir: %s\n"):format(mkdtemp_err),
+      "Warn"
+    )
+  end
+
+  return setmetatable({
+    console = console,
+    backend = detect_backend(),
+    tmp_dir = tmp_dir,
+    warned_missing_backend = false,
+    warned_decode = false,
+    active = {},
+  }, { __index = M })
+end
+
+function M:play(lump, volume, _sep)
+  if not self.backend or not self.tmp_dir then
+    if not self.warned_missing_backend then
+      self.warned_missing_backend = true
+      self.console:plugin_print(
+        "Sound effects disabled: no supported audio player was found "
+          .. ("(tried %s)\n"):format(backend_names),
+        "Warn"
+      )
+    end
+    return
+  end
+
+  local wav, decode_err = dmx_to_wav(lump, volume)
+  if not wav then
+    if not self.warned_decode then
+      self.warned_decode = true
+      self.console:plugin_print(
+        ("Failed to decode a DOOM sound lump: %s\n"):format(decode_err),
+        "Warn"
+      )
+    end
+    return
+  end
+
+  local path = fs.joinpath(
+    self.tmp_dir,
+    ("sfx-%d-%d.wav"):format(uv.hrtime(), math.random(0, 0xffff))
+  )
+  local ok, write_err = write_file(path, wav)
+  if not ok then
+    self.console:plugin_print(
+      ("Failed to write temporary sound file: %s\n"):format(write_err),
+      "Warn"
+    )
+    return
+  end
+
+  local ok, proc = pcall(vim.system, self.backend.cmd(path), {}, function()
+    self.active[path] = nil
+    cleanup_path(self.console, path)
+  end)
+  if not ok then
+    cleanup_path(self.console, path)
+    self.console:plugin_print(
+      ("Failed to play sound effect: %s\n"):format(proc),
+      "Warn"
+    )
+    return
+  end
+  self.active[path] = proc
+end
+
+function M:close()
+  for path, proc in pairs(self.active) do
+    pcall(proc.kill, proc, "sigterm")
+    self.active[path] = nil
+  end
+
+  if self.tmp_dir then
+    local ok, err = pcall(fs.rm, self.tmp_dir, { recursive = true })
+    if not ok and err then
+      self.console:plugin_print(
+        ("Failed to delete sound temp dir: %s\n"):format(err),
+        "Warn"
+      )
+    end
+  end
+end
+
+return M

--- a/lua/actually-doom/sound.lua
+++ b/lua/actually-doom/sound.lua
@@ -1,62 +1,22 @@
 local bit = require "bit"
 local fn = vim.fn
-local fs = vim.fs
-local uv = vim.uv
 
 --- @class (exact) ActuallyDoomSound
 --- @field console Console
---- @field backend table?
---- @field tmp_dir string?
+--- @field backend {exe: string, cmd: string[]}?
 --- @field warned_missing_backend boolean
 --- @field warned_decode boolean
---- @field active table<string, vim.SystemObj>
 ---
 --- @field new function
 local M = {}
 
 local backends = {
-  {
-    exe = "ffplay",
-    cmd = function(path)
-      return { "ffplay", "-autoexit", "-nodisp", "-loglevel", "quiet", path }
-    end,
-  },
-  {
-    exe = "mpv",
-    cmd = function(path)
-      return {
-        "mpv",
-        "--no-terminal",
-        "--really-quiet",
-        "--audio-display=no",
-        path,
-      }
-    end,
-  },
-  {
-    exe = "pw-play",
-    cmd = function(path)
-      return { "pw-play", path }
-    end,
-  },
-  {
-    exe = "paplay",
-    cmd = function(path)
-      return { "paplay", path }
-    end,
-  },
-  {
-    exe = "aplay",
-    cmd = function(path)
-      return { "aplay", "-q", path }
-    end,
-  },
-  {
-    exe = "afplay",
-    cmd = function(path)
-      return { "afplay", path }
-    end,
-  },
+  { exe = "ffplay", cmd = { "ffplay", "-autoexit", "-nodisp", "-loglevel", "quiet", "-i", "pipe:0" } },
+  { exe = "mpv", cmd = { "mpv", "--no-terminal", "--really-quiet", "--audio-display=no", "-" } },
+  { exe = "pw-play", cmd = { "pw-play", "-" } },
+  { exe = "paplay", cmd = { "paplay", "-" } },
+  { exe = "aplay", cmd = { "aplay", "-q", "-" } },
+  { exe = "afplay", cmd = { "afplay", "-" } },
 }
 
 local backend_names = "ffplay, mpv, pw-play, paplay, aplay, afplay"
@@ -112,10 +72,8 @@ local function dmx_to_wav(lump, volume)
     return nil, "DMX lump has invalid metadata"
   end
 
-  local pcm = lump:sub(9, 8 + sample_count)
-  pcm = scale_pcm_u8(pcm, volume)
-
-  local header = table.concat({
+  local pcm = scale_pcm_u8(lump:sub(9, 8 + sample_count), volume)
+  return table.concat({
     "RIFF",
     le_u32(36 + #pcm),
     "WAVE",
@@ -129,27 +87,8 @@ local function dmx_to_wav(lump, volume)
     le_u16(8),
     "data",
     le_u32(#pcm),
+    pcm,
   })
-
-  return header .. pcm
-end
-
-local function write_file(path, data)
-  local fd, open_err = uv.fs_open(path, "w", 384)
-  if not fd then
-    return nil, open_err
-  end
-
-  local written, write_err = uv.fs_write(fd, data, -1)
-  local closed_ok, close_err = uv.fs_close(fd)
-  if not written then
-    return nil, write_err
-  end
-  if not closed_ok then
-    return nil, close_err
-  end
-
-  return true
 end
 
 local function detect_backend()
@@ -160,41 +99,19 @@ local function detect_backend()
   end
 end
 
-local function cleanup_path(console, path)
-  local ok, err = pcall(fs.rm, path)
-  if not ok and err then
-    console:plugin_print(
-      ("Failed to delete temporary sound file: %s\n"):format(err),
-      "Warn"
-    )
-  end
-end
-
 --- @param console Console
 --- @return ActuallyDoomSound
 function M.new(console)
-  local tmp_dir_template =
-    fs.joinpath(fn.stdpath("run"), "actually-doom-sound.XXXXXX")
-  local tmp_dir, mkdtemp_err = uv.fs_mkdtemp(tmp_dir_template)
-  if not tmp_dir then
-    console:plugin_print(
-      ("Failed to create sound temp dir: %s\n"):format(mkdtemp_err),
-      "Warn"
-    )
-  end
-
   return setmetatable({
     console = console,
     backend = detect_backend(),
-    tmp_dir = tmp_dir,
     warned_missing_backend = false,
     warned_decode = false,
-    active = {},
   }, { __index = M })
 end
 
-function M:play(lump, volume, _sep)
-  if not self.backend or not self.tmp_dir then
+function M:play(lump, volume)
+  if not self.backend then
     if not self.warned_missing_backend then
       self.warned_missing_backend = true
       self.console:plugin_print(
@@ -218,48 +135,13 @@ function M:play(lump, volume, _sep)
     return
   end
 
-  local path = fs.joinpath(
-    self.tmp_dir,
-    ("sfx-%d-%d.wav"):format(uv.hrtime(), math.random(0, 0xffff))
-  )
-  local ok, write_err = write_file(path, wav)
-  if not ok then
-    self.console:plugin_print(
-      ("Failed to write temporary sound file: %s\n"):format(write_err),
-      "Warn"
-    )
-    return
-  end
-
-  local ok, proc = pcall(vim.system, self.backend.cmd(path), {}, function()
-    self.active[path] = nil
-    cleanup_path(self.console, path)
+  local ok, err = pcall(vim.system, self.backend.cmd, { stdin = wav }, function()
   end)
   if not ok then
-    cleanup_path(self.console, path)
     self.console:plugin_print(
-      ("Failed to play sound effect: %s\n"):format(proc),
+      ("Failed to play sound effect: %s\n"):format(err),
       "Warn"
     )
-    return
-  end
-  self.active[path] = proc
-end
-
-function M:close()
-  for path, proc in pairs(self.active) do
-    pcall(proc.kill, proc, "sigterm")
-    self.active[path] = nil
-  end
-
-  if self.tmp_dir then
-    local ok, err = pcall(fs.rm, self.tmp_dir, { recursive = true })
-    if not ok and err then
-      self.console:plugin_print(
-        ("Failed to delete sound temp dir: %s\n"):format(err),
-        "Warn"
-      )
-    end
   end
 end
 


### PR DESCRIPTION
hey, this wires up a simple fallback for sound effects.

right now sound is basically off since  is disabled and there isnt a real audio backend hooked up here. this change sends the doom sound lumps over the existing socket, decodes them in lua, turns them into wav, then plays them with an external audio player from nvim.

also added a couple small docs notes.

notes:
- this is sfx only for now
- music still isnt handled
- uses stuff like ffplay/mpv/pw-play/paplay/aplay/afplay if available

checked with lua syntax and a clean headless rebuild, both looked good